### PR TITLE
Update test harness to JUnit 5

### DIFF
--- a/fasttuple-core/pom.xml
+++ b/fasttuple-core/pom.xml
@@ -32,9 +32,9 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/Destroyer.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/Destroyer.java
@@ -3,6 +3,7 @@ package com.nickrobison.tuple;
 /**
  * Created by cliff on 5/15/14.
  */
+@FunctionalInterface
 public interface Destroyer<T> {
-    public void destroyArray(T[] ary);
+    void destroyArray(T[] ary);
 }

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/Loader.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/Loader.java
@@ -3,6 +3,7 @@ package com.nickrobison.tuple;
 /**
  * Created by cliff on 5/15/14.
  */
+@FunctionalInterface
 public interface Loader<T> {
-    public T[] createArray(int size) throws Exception;
+    T[] createArray(int size) throws Exception;
 }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/DirectTupleSchemaTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/DirectTupleSchemaTest.java
@@ -1,10 +1,9 @@
 package com.nickrobison.tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Type;
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Created by cliff on 5/4/14.
@@ -79,7 +78,7 @@ public class DirectTupleSchemaTest {
         schema.setInt(record,    2, 50010);
         schema.setShort(record,  3, (short)2500);
         schema.setFloat(record,  4, 0.1f);
-        schema.setLong(record,   5, 100000l);
+        schema.setLong(record,   5, 100000L);
         schema.setDouble(record, 6, 0.59403);
 
         assertEquals(6, schema.getByte(record, 0));
@@ -87,7 +86,7 @@ public class DirectTupleSchemaTest {
         assertEquals(50010, schema.getInt(record, 2));
         assertEquals(2500, schema.getShort(record, 3));
         assertEquals(0.1, schema.getFloat(record, 4), 0.00001);
-        assertEquals(100000l, schema.getLong(record, 5));
+        assertEquals(100000L, schema.getLong(record, 5));
         assertEquals(0.59403, schema.getDouble(record, 6), 0.00001);
     }
 
@@ -115,7 +114,7 @@ public class DirectTupleSchemaTest {
             tuples[i].setInt(3, 4);
             tuples[i].setShort(4, (short) 6);
             tuples[i].setFloat(5, 0.125f);
-            tuples[i].setLong(6, 1000000l);
+            tuples[i].setLong(6, 1000000L);
             tuples[i].setDouble(7, 0.125);
 
             assertEquals(1, tuples[i].getByte(1));
@@ -123,7 +122,7 @@ public class DirectTupleSchemaTest {
             assertEquals(4, tuples[i].getInt(3));
             assertEquals(6, tuples[i].getShort(4));
             assertEquals(0.125f, tuples[i].getFloat(5), 0.001);
-            assertEquals(1000000l, tuples[i].getLong(6));
+            assertEquals(1000000L, tuples[i].getLong(6));
             assertEquals(0.125, tuples[i].getDouble(7), 0.001);
         }
     }
@@ -153,7 +152,7 @@ public class DirectTupleSchemaTest {
             tuples[i].aInt(4);
             tuples[i].aShort((short) 6);
             tuples[i].aFloat(0.125f);
-            tuples[i].aLong(1000000l);
+            tuples[i].aLong(1000000L);
             tuples[i].aDouble(0.125);
 
             assertEquals(1, tuples[i].aByte());
@@ -161,7 +160,7 @@ public class DirectTupleSchemaTest {
             assertEquals(4, tuples[i].aInt());
             assertEquals(6, tuples[i].aShort());
             assertEquals(0.125f, tuples[i].aFloat(), 0.001);
-            assertEquals(1000000l, tuples[i].aLong());
+            assertEquals(1000000L, tuples[i].aLong());
             assertEquals(0.125, tuples[i].aDouble(), 0.001);
         }
     }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/HeapTupleSchemaTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/HeapTupleSchemaTest.java
@@ -1,16 +1,17 @@
 package com.nickrobison.tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Created by nickrobison on 1/29/18.
  */
 public class HeapTupleSchemaTest {
 
-    public HeapTupleSchemaTest() {}
+    public HeapTupleSchemaTest() {
+    }
 
     @Test
     public void createTupleArrayTest() throws Exception {
@@ -28,7 +29,7 @@ public class HeapTupleSchemaTest {
         FastTuple[] tuples = schema.createTupleArray(10);
         assertEquals(10, tuples.length);
 
-        for (int i=0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
             assertNotNull(tuples[i]);
 
             tuples[i].setByte(1, (byte) 1);
@@ -36,7 +37,7 @@ public class HeapTupleSchemaTest {
             tuples[i].setInt(3, 4);
             tuples[i].setShort(4, (short) 6);
             tuples[i].setFloat(5, 0.125f);
-            tuples[i].setLong(6, 1000000l);
+            tuples[i].setLong(6, 1000000L);
             tuples[i].setDouble(7, 0.125);
 
             assertEquals(1, tuples[i].getByte(1));
@@ -44,7 +45,7 @@ public class HeapTupleSchemaTest {
             assertEquals(4, tuples[i].getInt(3));
             assertEquals(6, tuples[i].getShort(4));
             assertEquals(0.125f, tuples[i].getFloat(5), 0.001);
-            assertEquals(1000000l, tuples[i].getLong(6));
+            assertEquals(1000000L, tuples[i].getLong(6));
             assertEquals(0.125, tuples[i].getDouble(7), 0.001);
         }
     }
@@ -63,10 +64,10 @@ public class HeapTupleSchemaTest {
                 heapMemory().
                 build();
 
-        TypedTuple[] tuples = schema.createTypedTupleArray(TypedTuple.class,10);
+        TypedTuple[] tuples = schema.createTypedTupleArray(TypedTuple.class, 10);
         assertEquals(10, tuples.length);
 
-        for (int i=0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
             assertNotNull(tuples[i]);
 
             tuples[i].aByte((byte) 1);
@@ -74,7 +75,7 @@ public class HeapTupleSchemaTest {
             tuples[i].aInt(4);
             tuples[i].aShort((short) 6);
             tuples[i].aFloat(0.125f);
-            tuples[i].aLong(1000000l);
+            tuples[i].aLong(1000000L);
             tuples[i].aDouble(0.125);
 
             assertEquals(1, tuples[i].aByte());
@@ -82,7 +83,7 @@ public class HeapTupleSchemaTest {
             assertEquals(4, tuples[i].aInt());
             assertEquals(6, tuples[i].aShort());
             assertEquals(0.125f, tuples[i].aFloat(), 0.001);
-            assertEquals(1000000l, tuples[i].aLong());
+            assertEquals(1000000L, tuples[i].aLong());
             assertEquals(0.125, tuples[i].aDouble(), 0.001);
         }
     }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/TuplePoolTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/TuplePoolTest.java
@@ -1,71 +1,52 @@
 package com.nickrobison.tuple;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Created by cliff on 5/12/14.
  */
-@RunWith(JUnit4.class)
 public class TuplePoolTest {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void createPoolAndCheckoutTest() throws Exception {
-        TuplePool<Long> pool = new TuplePool<>(10, false,
-                new Loader<Long>() {
-                    @Override
-                    public Long[] createArray(int size) throws Exception {
+    public void createPoolAndCheckoutTest() {
+        assertThrows(IllegalStateException.class, () -> {
+            TuplePool<Long> pool = new TuplePool<>(10, false,
+                    size -> {
                         Long[] ary = new Long[size];
-                        for (int i=0; i<ary.length; i++) {
-                            ary[i] = 0L;
-                        }
+                        Arrays.fill(ary, 0L);
                         return ary;
-                    }
-                },
-                new Destroyer<Long>() {
-                    @Override
-                    public void destroyArray(Long[] ary) {
+                    },
+                    ary -> {
 
                     }
-                }
-        );
+            );
 
-        for (int i=0; i<10; i++) {
-            Long n = pool.checkout();
-            assertEquals(new Long(0L), n);
-        }
-        exception.expect(IllegalStateException.class);
-        pool.checkout();
+            for (int i = 0; i < 10; i++) {
+                Long n = pool.checkout();
+                assertEquals(new Long(0L), n);
+            }
+            pool.checkout();
+        });
     }
 
     @Test
-    public void expandPoolTest() throws Exception {
+    public void expandPoolTest() {
         TuplePool<Long> pool = new TuplePool<>(10, true,
-                new Loader<Long>() {
-                    @Override
-                    public Long[] createArray(int size) throws Exception {
-                        Long[] ary = new Long[size];
-                        for (int i=0; i<ary.length; i++) {
-                            ary[i] = 0L;
-                        }
-                        return ary;
-                    }
+                size -> {
+                    Long[] ary = new Long[size];
+                    Arrays.fill(ary, 0L);
+                    return ary;
                 },
-                new Destroyer<Long>() {
-                    @Override
-                    public void destroyArray(Long[] ary) {
+                ary -> {
 
-                    }
                 }
         );
-        for (int i=0; i<11; i++) {
+        for (int i = 0; i < 11; i++) {
             Long n = pool.checkout();
             assertEquals(new Long(0L), n);
         }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/DirectTupleCodeGeneratorTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/DirectTupleCodeGeneratorTest.java
@@ -3,9 +3,9 @@ package com.nickrobison.tuple.codegen;
 import com.nickrobison.tuple.DirectTupleSchema;
 import com.nickrobison.tuple.FastTuple;
 import com.nickrobison.tuple.TupleSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by cliff on 5/5/14.
@@ -26,7 +26,7 @@ public class DirectTupleCodeGeneratorTest {
                 build();
 
         DirectTupleCodeGenerator codegen = new DirectTupleCodeGenerator(null, schema.getFieldNames(), schema.getFieldTypes(), schema.getLayout());
-        Class clazz = codegen.cookToClass();
+        Class<?> clazz = codegen.cookToClass();
         assertGetterAndSetterGenerated(clazz, "a", long.class);
         assertGetterAndSetterGenerated(clazz, "b", int.class);
         assertGetterAndSetterGenerated(clazz, "c", short.class);
@@ -113,12 +113,12 @@ public class DirectTupleCodeGeneratorTest {
         assertTrue(tuple instanceof StaticBinding);
     }
 
-    public void assertGetterAndSetterGenerated(Class clazz, String name, Class type) throws Exception {
+    public void assertGetterAndSetterGenerated(Class<?> clazz, String name, Class<?> type) throws Exception {
         assertEquals(type, clazz.getDeclaredMethod(name).getReturnType());
         assertNotNull(clazz.getDeclaredMethod(name, type));
     }
 
-    public void assertGetterAndSetterRoundTrip(Object tuple, Class clazz, String name, Class type, Object value) throws Exception {
+    public void assertGetterAndSetterRoundTrip(Object tuple, Class<?> clazz, String name, Class<?> type, Object value) throws Exception {
         clazz.getDeclaredMethod(name, type).invoke(tuple, value);
         assertEquals(value, clazz.getDeclaredMethod(name).invoke(tuple));
     }
@@ -153,9 +153,9 @@ public class DirectTupleCodeGeneratorTest {
         }
     }
 
-    public static interface StaticBinding {
-        public void a(long a);
-        public long a();
+    public interface StaticBinding {
+        void a(long a);
+        long a();
     }
 }
 

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/HeapTupleCodeGeneratorTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/HeapTupleCodeGeneratorTest.java
@@ -3,9 +3,9 @@ package com.nickrobison.tuple.codegen;
 import com.nickrobison.tuple.FastTuple;
 import com.nickrobison.tuple.HeapTupleSchema;
 import com.nickrobison.tuple.TupleSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by cliff on 5/9/14.
@@ -25,7 +25,7 @@ public class HeapTupleCodeGeneratorTest {
                 build();
 
         HeapTupleCodeGenerator codegen = new HeapTupleCodeGenerator(null, schema.getFieldNames(), schema.getFieldTypes());
-        Class clazz = codegen.cookToClass();
+        Class<?> clazz = codegen.cookToClass();
         assertGetterAndSetterGenerated(clazz, "a", long.class);
         assertGetterAndSetterGenerated(clazz, "b", int.class);
         assertGetterAndSetterGenerated(clazz, "c", short.class);
@@ -112,12 +112,12 @@ public class HeapTupleCodeGeneratorTest {
         assertTrue(tuple instanceof StaticBinding);
     }
 
-    public void assertGetterAndSetterGenerated(Class clazz, String name, Class type) throws Exception {
+    public void assertGetterAndSetterGenerated(Class<?> clazz, String name, Class<?> type) throws Exception {
         assertEquals(type, clazz.getDeclaredMethod(name).getReturnType());
         assertNotNull(clazz.getDeclaredMethod(name, type));
     }
 
-    public void assertGetterAndSetterRoundTrip(Object tuple, Class clazz, String name, Class type, Object value) throws Exception {
+    public void assertGetterAndSetterRoundTrip(Object tuple, Class<?> clazz, String name, Class<?> type, Object value) throws Exception {
         clazz.getDeclaredMethod(name, type).invoke(tuple, value);
         assertEquals(value, clazz.getDeclaredMethod(name).invoke(tuple));
     }
@@ -152,8 +152,8 @@ public class HeapTupleCodeGeneratorTest {
         }
     }
 
-    public static interface StaticBinding {
-        public void a(long a);
-        public long a();
+    public interface StaticBinding {
+        void a(long a);
+        long a();
     }
 }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/TupleExpressionGeneratorTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/TupleExpressionGeneratorTest.java
@@ -2,9 +2,10 @@ package com.nickrobison.tuple.codegen;
 
 import com.nickrobison.tuple.FastTuple;
 import com.nickrobison.tuple.TupleSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by cliff on 5/12/14.


### PR DESCRIPTION
No more JUnit 4. Pretty simple find/replace, one test was changed in order to use the new `assertThrows` method in 5.

Updated the tests to address some IntelliJ warnings.

Loader and Destroy interfaces are now marked as functional.

Closes #16 