### PR TITLE
Fix javadoc generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,21 +45,21 @@ stages:
             Linux_Java8:
               imageName: 'ubuntu-latest'
               jdk: '1.8'
-#            Linux_Java11:
-#              imageName: 'ubuntu-latest'
-#              jdk: '1.11'
+            Linux_Java11:
+              imageName: 'ubuntu-latest'
+              jdk: '1.11'
             Mac_Java8:
               jdk: '1.8'
               imageName: 'macos-10.14'
-                # Mac_Java11:
-                #   jdk: '1.11'
-                #   imageName: 'macos-10.14'
+            Mac_Java11:
+              jdk: '1.11'
+              imageName: 'macos-10.14'
             Windows_Java8:
               imageName: 'vs2017-win2016'
               jdk: '1.8'
-#            Windows_Java11:
-#              imageName: 'vs2017-win2016'
-#              jdk: '1.11'
+            Windows_Java11:
+              imageName: 'vs2017-win2016'
+              jdk: '1.11'
         steps:
           - download: current
             artifact: artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <!--                Manually specifying Java 8 source information here due to JDK bug: https://bugs.openjdk.java.net/browse/JDK-8212233-->
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>


### PR DESCRIPTION
Work around JDK bug that prevents Javadocs from building under Java 11 when the source is Java 8.

Re-enable Java 11 builds now that Javadocs are working correctly.