### PR TITLE
Cleanup workflow triggers

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -3,11 +3,10 @@ on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
   push:
     branches:
-      - "**"
+      - master
+  pull_request:
     paths:
       - .github/workflows/coverity.yaml
-  schedule:
-    - cron: '0 0 1 * *' # Monthly on the 1st at 00:00 UTC
 
 jobs:
   scan:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,14 @@
 name: Maven Deploy
 on:
   workflow_dispatch: # because sometimes you just want to force a branch to have tests run
-  push:
+  workflow_run:
+    workflows:
+      - 'Build and test'
+    types:
+      - completed
     branches:
       - master
+  pull_request:
     paths:
       - .github/workflows/deploy.yaml
 


### PR DESCRIPTION
Fix triggers for deploy script:
- Run whenever we change the file.
- Run after Build runs, on master.