### PR TITLE
Support getting field indexes from field names

### DIFF
--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/SizeOf.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/SizeOf.java
@@ -7,7 +7,7 @@ public final class SizeOf {
 
     private SizeOf() {}
 
-    public static int sizeOf(Class c) {
+    public static int sizeOf(Class<?> c) {
         if (c.equals(Byte.TYPE)) {
             return 1;
         } else if (c.equals(Short.TYPE) || c.equals(Character.TYPE)) {

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/TupleSchema.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/TupleSchema.java
@@ -11,9 +11,9 @@ import java.util.List;
  */
 public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTuple> {
     protected final String[] fieldNames;
-    protected final Class[] fieldTypes;
-    protected final Class iface;
-    protected Class clazz;
+    protected final Class<?>[] fieldTypes;
+    protected final Class<?> iface;
+    protected Class<?> clazz;
     protected final TuplePool<FastTuple> pool;
 
     public static Builder builder() {
@@ -41,11 +41,11 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
     }
 
     public static class Builder {
-        private List<String> fn;
-        private List<Class> ft;
-        private Class iface;
+        private final List<String> fn;
+        private final List<Class<?>> ft;
+        private Class<?> iface;
         private int poolSize;
-        private int threads;
+        private final int threads;
         private boolean createWhenExhausted = false;
 
         public Builder(Builder builder) {
@@ -74,7 +74,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
          * @param fieldType - {@link Class} type of field
          * @return - {@link Builder}
          */
-        public Builder addField(String fieldName, Class fieldType) {
+        public Builder addField(String fieldName, Class<?> fieldType) {
             fn.add(fieldName);
             ft.add(fieldType);
             return this;
@@ -87,7 +87,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
          * @param iface - {@link Class} interface to implement
          * @return - {@link Builder}
          */
-        public Builder implementInterface(Class iface) {
+        public Builder implementInterface(Class<?> iface) {
             this.iface = iface;
             return this;
         }
@@ -104,13 +104,13 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
             return this;
         }
 
-        public Builder addFieldTypes(Class... fieldTypes) {
+        public Builder addFieldTypes(Class<?>... fieldTypes) {
             Collections.addAll(ft, fieldTypes);
             return this;
         }
 
-        public Builder addFieldTypes(Iterable<Class> fieldTypes) {
-            for (Class c : fieldTypes) {
+        public Builder addFieldTypes(Iterable<Class<?>> fieldTypes) {
+            for (Class<?> c : fieldTypes) {
                 ft.add(c);
             }
             return this;
@@ -191,7 +191,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
         return Arrays.deepHashCode(new Object[]{fieldNames, fieldTypes});
     }
 
-    public Class tupleClass() {
+    public Class<?> tupleClass() {
         return clazz;
     }
 
@@ -199,7 +199,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
         return fieldNames.clone();
     }
 
-    public Class[] getFieldTypes() {
+    public Class<?>[] getFieldTypes() {
         return fieldTypes.clone();
     }
 

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/TupleSchema.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/TupleSchema.java
@@ -33,8 +33,8 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
         }
         this.iface = builder.iface;
         if (iface != null && !iface.isInterface()) {
-                throw new IllegalArgumentException(iface.getName() +  " is not an interface");
-            }
+            throw new IllegalArgumentException(iface.getName() + " is not an interface");
+        }
 
         this.pool = new TuplePool<>(builder.poolSize, builder.createWhenExhausted, this, this);
 
@@ -163,7 +163,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
     @Override
     public String toString() {
         StringBuilder str = new StringBuilder("(");
-        for (int i=0; i<fieldNames.length; i++) {
+        for (int i = 0; i < fieldNames.length; i++) {
             str.append("'");
             str.append(fieldNames[i]);
             str.append("':");
@@ -188,7 +188,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
 
     @Override
     public int hashCode() {
-        return Arrays.deepHashCode(new Object[] {fieldNames, fieldTypes});
+        return Arrays.deepHashCode(new Object[]{fieldNames, fieldTypes});
     }
 
     public Class tupleClass() {
@@ -201,6 +201,23 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
 
     public Class[] getFieldTypes() {
         return fieldTypes.clone();
+    }
+
+    /**
+     * Retrieves the index of a field by its name. The index is 1-based, meaning the first field is index 1.
+     *
+     * @param name the name of the field to find
+     * @return the 1-based index of the field
+     * @throws IllegalArgumentException if the field name is not found in the schema
+     */
+    public int getFieldIndex(String name) {
+        final String[] cloned = fieldNames.clone();
+        for (int i = 0; i < cloned.length; i++) {
+            if (cloned[i].equals(name)) {
+                return i + 1;
+            }
+        }
+        throw new IllegalArgumentException("Field " + name + " not found");
     }
 
     protected abstract void generateClass() throws Exception;
@@ -218,7 +235,7 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
      * Use care to call {@link Builder#implementInterface(Class)} before using this method
      *
      * @param clazz - {@link Class} implemented by the Tuple
-     * @param <T> - {@link T} type parameter
+     * @param <T>   - {@link T} type parameter
      * @return - {@link FastTuple} case to type {@link T}
      * @throws Exception - Throws an exception if unable to allocate tuple or cast to the specified type
      */
@@ -239,8 +256,8 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
      * in adjacent memory, however with the heap based allocation this is not guaranteed.
      *
      * @param clazz - {@link Class} implemented by the Tuple
-     * @param size - the number of tuples in the array
-     * @param <T> - {@link T} type parameter
+     * @param size  - the number of tuples in the array
+     * @param <T>   - {@link T} type parameter
      * @return - Array of {@link FastTuple} cast to type {@link T}
      * @throws Exception - Throws is unable to allocate tuple array or cast to the specified type
      */
@@ -254,10 +271,10 @@ public abstract class TupleSchema implements Loader<FastTuple>, Destroyer<FastTu
     public abstract void destroyTuple(FastTuple tuple);
 
     /**
-     ** Deallocates memory for a typed tuple.
+     * * Deallocates memory for a typed tuple.
      *
      * @param tuple - {@link FastTuple} cast to type {@link T}
-     * @param <T> - {@link T} underlying class implemented by tuples
+     * @param <T>   - {@link T} underlying class implemented by tuples
      */
     public abstract <T> void destroyTypedTuple(T tuple);
 

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/DirectTupleCodeGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/DirectTupleCodeGenerator.java
@@ -14,9 +14,9 @@ import static com.nickrobison.tuple.codegen.CodegenUtil.PUBLIC;
  * Created by cliff on 5/5/14.
  */
 public class DirectTupleCodeGenerator extends TupleCodeGenerator {
-    protected int[] layout;
+    protected final int[] layout;
 
-    public DirectTupleCodeGenerator(Class iface, String[] fieldNames, Class[] fieldTypes, int[] layout) {
+    public DirectTupleCodeGenerator(Class<?> iface, String[] fieldNames, Class<?>[] fieldTypes, int[] layout) {
         super(iface, fieldNames, fieldTypes);
         this.layout = layout.clone();
     }
@@ -47,7 +47,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl() throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl() {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int i = 0; i < fieldNames.length; i++) {
             list.add(
@@ -64,7 +64,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class type) throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class<?> type) {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int n = 0; n < fieldNames.length; n++) {
             if (!type.equals(fieldTypes[n])) {
@@ -102,7 +102,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class type) throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class<?> type) throws CompileException {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int n = 0; n < fieldNames.length; n++) {
             if (!type.equals(fieldTypes[n])) {
@@ -122,7 +122,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected Java.Rvalue generateGetInvocation(Class type, int index) throws CompileException {
+    protected Java.Rvalue generateGetInvocation(Class<?> type, int index) {
         return new Java.MethodInvocation(loc,
                 new Java.AmbiguousName(loc, new String[]{"unsafe"}),
                 "get" + accessorForType(type),
@@ -136,7 +136,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected Java.Rvalue generateSetInvocation(Class type, int index, String value) throws CompileException {
+    protected Java.Rvalue generateSetInvocation(Class<?> type, int index, String value) {
         return new Java.MethodInvocation(loc,
                 new Java.AmbiguousName(loc, new String[]{"unsafe"}),
                 "put" + accessorForType(type),
@@ -150,7 +150,7 @@ public class DirectTupleCodeGenerator extends TupleCodeGenerator {
         );
     }
 
-    protected String accessorForType(Class type) {
+    protected String accessorForType(Class<?> type) {
         if (type.equals(Byte.TYPE)) {
             return "Byte";
         } else if (type.equals(Character.TYPE)) {

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/HeapTupleCodeGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/HeapTupleCodeGenerator.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public class HeapTupleCodeGenerator extends TupleCodeGenerator {
 
-    public HeapTupleCodeGenerator(Class iface, String[] fieldName, Class[] fieldType) {
+    public HeapTupleCodeGenerator(Class<?>iface, String[] fieldName, Class<?>[] fieldType) {
         super(iface, fieldName, fieldType);
     }
 
@@ -35,7 +35,7 @@ public class HeapTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl() throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl() {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int i = 0; i < fieldTypes.length; i++) {
             list.add(
@@ -52,7 +52,7 @@ public class HeapTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class type) throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class<?> type) {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int i = 0; i < fieldTypes.length; i++) {
             if (!type.equals(fieldTypes[i])) {
@@ -92,7 +92,7 @@ public class HeapTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class type) throws CompileException {
+    protected List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class<?> type) throws CompileException {
         List<Java.SwitchStatement.SwitchBlockStatementGroup> list = new ArrayList<>();
         for (int i = 0; i < fieldTypes.length; i++) {
             if (!type.equals(fieldTypes[i])) {
@@ -115,12 +115,12 @@ public class HeapTupleCodeGenerator extends TupleCodeGenerator {
     }
 
     @Override
-    protected Java.Rvalue generateGetInvocation(Class type, int index) throws CompileException {
+    protected Java.Rvalue generateGetInvocation(Class<?> type, int index) {
         return new Java.FieldAccessExpression(loc, new Java.ThisReference(loc), fieldNames[index]);
     }
 
     @Override
-    protected Java.Rvalue generateSetInvocation(Class type, int index, String value) throws CompileException {
+    protected Java.Rvalue generateSetInvocation(Class<?> type, int index, String value) {
         return new Java.Assignment(loc, new Java.FieldAccessExpression(loc, new Java.ThisReference(loc), fieldNames[index]), "=",
                 new Java.Cast(loc, classToRefType(fieldTypes[index]), new Java.AmbiguousName(loc, new String[]{value})));
     }

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleAllocatorGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleAllocatorGenerator.java
@@ -19,9 +19,9 @@ public class TupleAllocatorGenerator extends ClassBodyEvaluator {
         FastTuple allocate();
     }
 
-    private final Class allocatorClass;
+    private final Class<?> allocatorClass;
 
-    public TupleAllocatorGenerator(Class tupleClass) throws Exception {
+    public TupleAllocatorGenerator(Class<?> tupleClass) throws Exception {
         setParentClassLoader(tupleClass.getClassLoader());
         String className = tupleClass.getName() + "Allocator";
         setClassName(packageName + "." + className);
@@ -36,7 +36,7 @@ public class TupleAllocatorGenerator extends ClassBodyEvaluator {
         return (TupleAllocator) allocatorClass.getConstructor().newInstance();
     }
 
-    private Java.PackageMemberClassDeclaration makeClassDefinition(Location loc, Class tupleClass, String className) {
+    private Java.PackageMemberClassDeclaration makeClassDefinition(Location loc, Class <?>tupleClass, String className) {
         Java.PackageMemberClassDeclaration cd = new Java.PackageMemberClassDeclaration(
                 loc,
                 null,

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleCodeGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleCodeGenerator.java
@@ -21,8 +21,8 @@ import static java.lang.Character.toUpperCase;
 public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
     public static final String VALUE = "value";
     public static final String INDEX = "index";
-    private static AtomicLong counter = new AtomicLong(0L);
-    protected static Class[] types = new Class[]{
+    private static final AtomicLong counter = new AtomicLong(0L);
+    protected static final Class<?>[] types = new Class[]{
             Long.TYPE,
             Integer.TYPE,
             Short.TYPE,
@@ -31,13 +31,13 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
             Float.TYPE,
             Double.TYPE
     };
-    protected Class iface;
-    protected String[] fieldNames;
-    protected Class[] fieldTypes;
-    protected Location loc;
-    protected String className;
+    protected final Class<?> iface;
+    protected final String[] fieldNames;
+    protected final Class<?>[] fieldTypes;
+    protected final Location loc;
+    protected final String className;
 
-    protected TupleCodeGenerator(Class iface, String[] fieldNames, Class[] fieldTypes) {
+    protected TupleCodeGenerator(Class<?> iface, String[] fieldNames, Class<?>[] fieldTypes) {
         this.loc = new Location("", (short) 0, (short) 0);
         this.iface = iface;
         this.fieldNames = fieldNames.clone();
@@ -49,7 +49,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
 
     protected abstract Java.FieldDeclaration[] generateFields();
 
-    public Class cookToClass() throws CompileException {
+    public Class<?> cookToClass() throws CompileException {
         return compileToClass(makeCompilationUnit());
     }
 
@@ -57,7 +57,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         Java.CompilationUnit cu = new Java.CompilationUnit(null, new SingleTypeImportDeclaration[]{new SingleTypeImportDeclaration(loc, "com.nickrobison.tuple.unsafe.Coterie".split("\\."))});
         Location cuLoc = new Location("", ((short) 0), ((short) 0));
         cu.setPackageDeclaration(new Java.PackageDeclaration(cuLoc, "com.nickrobison.tuple"));
-        Class[] ifaces;
+        Class<?>[] ifaces;
         if (iface != null) {
             ifaces = new Class[]{iface};
         } else {
@@ -81,7 +81,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
 
         for (int i = 0; i < fieldNames.length; i++) {
             String name = fieldNames[i];
-            Class type = fieldTypes[i];
+            Class<?> type = fieldTypes[i];
 
 
             cd.addDeclaredMethod(generateGetter(name, type, i));
@@ -98,7 +98,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         return cu;
     }
 
-    protected Java.MethodDeclarator generateIndexedGetter() throws CompileException {
+    protected Java.MethodDeclarator generateIndexedGetter() {
         return new Java.MethodDeclarator(
                 loc,
                 null,
@@ -116,9 +116,9 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         );
     }
 
-    protected List<Java.MethodDeclarator> generateIndexedTypedGetters() throws CompileException {
+    protected List<Java.MethodDeclarator> generateIndexedTypedGetters() {
         List<Java.MethodDeclarator> methods = new ArrayList<>();
-        for (Class type : types) {
+        for (Class<?> type : types) {
             methods.add(new Java.MethodDeclarator(
                     loc,
                     null,
@@ -140,7 +140,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
 
     protected List<Java.MethodDeclarator> generateIndexedTypedSetters() throws CompileException {
         List<Java.MethodDeclarator> methods = new ArrayList<>();
-        for (Class type : types) {
+        for (Class<?> type : types) {
             methods.add(new Java.MethodDeclarator(
                     loc,
                     null,
@@ -182,15 +182,15 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         );
     }
 
-    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl() throws CompileException;
+    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl();
 
-    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class type) throws CompileException;
+    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedGetterImpl(Class<?> type);
 
     protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value) throws CompileException;
 
-    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class type) throws CompileException;
+    protected abstract List<Java.SwitchStatement.SwitchBlockStatementGroup> generateIndexedSetterImpl(String value, Class<?> type) throws CompileException;
 
-    protected Java.MethodDeclarator generateGetter(String name, Class type, int index) throws CompileException {
+    protected Java.MethodDeclarator generateGetter(String name, Class<?> type, int index) {
         // unsafe().get* (long)
         Java.BlockStatement st = new Java.ReturnStatement(loc, generateGetInvocation(type, index));
         return new Java.MethodDeclarator(
@@ -207,7 +207,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         );
     }
 
-    protected Java.MethodDeclarator generateSetter(String name, Class type, int index) throws CompileException {
+    protected Java.MethodDeclarator generateSetter(String name, Class<?> type, int index) throws CompileException {
         Java.BlockStatement st = new Java.ExpressionStatement(generateSetInvocation(type, index, VALUE));
         return new Java.MethodDeclarator(
                 loc,
@@ -225,16 +225,16 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         );
     }
 
-    protected abstract Java.Rvalue generateGetInvocation(Class type, int index) throws CompileException;
+    protected abstract Java.Rvalue generateGetInvocation(Class<?> type, int index);
 
-    protected abstract Java.Rvalue generateSetInvocation(Class type, int index, String value) throws CompileException;
+    protected abstract Java.Rvalue generateSetInvocation(Class<?> type, int index, String value);
 
     protected String capitalize(String st) {
         return toUpperCase(st.charAt(0)) + st.substring(1);
     }
 
 
-    protected Java.Primitive primIndex(Class type) {
+    protected Java.Primitive primIndex(Class<?> type) {
         if (type.equals(Long.TYPE)) return Java.Primitive.LONG;
         if (type.equals(Integer.TYPE)) return Java.Primitive.INT;
         if (type.equals(Short.TYPE)) return Java.Primitive.SHORT;
@@ -245,7 +245,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
         return Java.Primitive.VOID;
     }
 
-    protected String primToBox(Class type) {
+    protected String primToBox(Class<?> type) {
         if (type.equals(Long.TYPE)) return "Long";
         if (type.equals(Integer.TYPE)) return "Integer";
         if (type.equals(Short.TYPE)) return "Short";
@@ -272,7 +272,7 @@ public abstract class TupleCodeGenerator extends ClassBodyEvaluator {
                 ));
     }
 
-    protected Java.Type classToRefType(Class type) {
+    protected Java.Type classToRefType(Class<?> type) {
         if (type.isPrimitive()) {
             return new Java.ReferenceType(loc, new Java.NormalAnnotation[]{}, primToBox(type).split("\\."), null);
         } else {

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleExpressionGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleExpressionGenerator.java
@@ -62,10 +62,10 @@ public class TupleExpressionGenerator extends ClassBodyEvaluator {
     private static final AtomicLong counter = new AtomicLong(0);
     private final String expression;
     private final TupleSchema schema;
-    private Class evaluatorClass;
+    private Class<?> evaluatorClass;
     private Object evaluator;
-    private final Class iface;
-    private final Class returnType;
+    private final Class<?> iface;
+    private final Class<?> returnType;
 
     public static Builder builder() {
         return new Builder();
@@ -129,7 +129,7 @@ public class TupleExpressionGenerator extends ClassBodyEvaluator {
 
     }
 
-    private TupleExpressionGenerator(TupleSchema schema, String expression, Class iface, Class returnType) throws Exception {
+    private TupleExpressionGenerator(TupleSchema schema, String expression, Class<?> iface, Class<?> returnType) throws Exception {
         this.schema = schema;
         this.expression = expression;
         this.iface = iface;
@@ -226,7 +226,7 @@ public class TupleExpressionGenerator extends ClassBodyEvaluator {
         }
     }
 
-    private Java.FunctionDeclarator.FormalParameters generateArgs(Location loc, Class c) {
+    private Java.FunctionDeclarator.FormalParameters generateArgs(Location loc, Class<?> c) {
         return new Java.FunctionDeclarator.FormalParameters(
                 loc,
                 new Java.FunctionDeclarator.FormalParameter[] {

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/SchemaBuilderTests.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/SchemaBuilderTests.java
@@ -32,8 +32,8 @@ public class SchemaBuilderTests {
         final IllegalArgumentException exn = assertThrows(IllegalArgumentException.class, () -> TupleSchema.builder()
                 .addFieldNames("Test", "Field")
                 .addFieldTypes(String.class).
-                        heapMemory().
-                        build());
+                heapMemory().
+                build());
 
         assertEquals("fieldNames and fieldTypes must have equal length", exn.getLocalizedMessage());
     }
@@ -43,14 +43,14 @@ public class SchemaBuilderTests {
         assertThrows(IllegalArgumentException.class, () -> TupleSchema.builder()
                 .addFieldNames("Test", "Field")
                 .addFieldTypes(String.class, Integer.class).
-                        heapMemory().
-                        build());
+                heapMemory().
+                build());
 
         assertThrows(IllegalArgumentException.class, () -> TupleSchema.builder()
                 .addFieldNames("Test", "Field")
                 .addFieldTypes(Boolean.class, Integer.class).
-                        heapMemory().
-                        build());
+                heapMemory().
+                build());
     }
 
     @Test
@@ -90,5 +90,11 @@ public class SchemaBuilderTests {
         assertEquals("('a':long,'b':long,'c':long)", schema.toString());
         assertEquals(schema.hashCode(), schema.hashCode());
         assertNotEquals(schema.hashCode(), s2.hashCode());
+
+        final int aIdx = schema.getFieldIndex("a");
+        assertEquals(1, aIdx);
+        final FastTuple tuple = schema.createTuple();
+        tuple.setLong(aIdx, 123456789L);
+        assertThrows(IllegalArgumentException.class, () -> schema.getFieldIndex("nope"));
     }
 }

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/SchemaBuilderTests.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/SchemaBuilderTests.java
@@ -16,7 +16,7 @@ public class SchemaBuilderTests {
     void testNonInterface() {
 
         final List<String> nameList = Arrays.asList("a", "b", "c");
-        final List<Class> typeList = Arrays.asList(Long.TYPE, Long.TYPE, Long.TYPE);
+        final List<Class<?>> typeList = Arrays.asList(Long.TYPE, Long.TYPE, Long.TYPE);
         final IllegalArgumentException exn = assertThrows(IllegalArgumentException.class, () -> TupleSchema.builder().
                 addFieldNames(nameList).
                 addFieldTypes(typeList).
@@ -83,9 +83,10 @@ public class SchemaBuilderTests {
                 addField("d", Integer.TYPE).
                 heapMemory().
                 build();
+        //noinspection EqualsWithItself
         assertEquals(schema, schema);
         //noinspection RedundantCast - Suppress this because we need to test the equals method
-        assertNotEquals((Object) schema, (Object) "I'm a string");
+        assertNotEquals((Object) "I'm a string", (Object) schema);
         assertNotEquals(schema, s2);
         assertEquals("('a':long,'b':long,'c':long)", schema.toString());
         assertEquals(schema.hashCode(), schema.hashCode());


### PR DESCRIPTION
Small PR to add a helper method to `TupleSchema` to support getting the field index for a given field name.

This is helpful because getters/setters are 1-indexed, which is a bit confusing.

I also went through the code and cleaned up a bunch of warnings.