### PR TITLE
Improve Pitest code coverage

### DIFF
--- a/fasttuple-core/build.gradle.kts
+++ b/fasttuple-core/build.gradle.kts
@@ -18,8 +18,11 @@ dependencies {
 }
 
 configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
-    junit5PluginVersion.set("0.12")
+    pitestVersion = "1.19.0"
+    junit5PluginVersion = "1.2.2"
+    threads = 4
     targetClasses.add("com.nickrobison.tuple.*")
+    outputFormats.add("HTML")
 }
 
 tasks.test {

--- a/fasttuple-core/build.gradle.kts
+++ b/fasttuple-core/build.gradle.kts
@@ -22,6 +22,7 @@ configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
     junit5PluginVersion = "1.2.2"
     threads = 4
     targetClasses.add("com.nickrobison.tuple.*")
+    excludedClasses.add("com.nickrobison.tuple.*DirectTuple*")
     outputFormats.add("HTML")
 }
 

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/TuplePool.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/TuplePool.java
@@ -86,6 +86,7 @@ public class TuplePool<T> {
             for (T tuple : tuples) {
                 deque.push(tuple);
             }
+            assert !references.isEmpty();
         } catch (Exception ex) {
             throw new IllegalStateException("Unable to reload Tuple pool");
         }

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/TuplePool.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/TuplePool.java
@@ -82,6 +82,7 @@ public class TuplePool<T> {
         try {
             final T[] tuples = loader.createArray(reloadSize);
             size += reloadSize;
+            references.add(tuples);
             for (T tuple : tuples) {
                 deque.push(tuple);
             }
@@ -97,5 +98,8 @@ public class TuplePool<T> {
         }
         references.clear();
         pool.remove();
+        assert references.isEmpty();
     }
+
+
 }

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleAllocatorGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleAllocatorGenerator.java
@@ -7,7 +7,7 @@ import org.codehaus.janino.Java;
 
 import java.util.Collections;
 
-import static com.nickrobison.tuple.codegen.CodegenUtil.*;
+import static com.nickrobison.tuple.codegen.CodegenUtil.emptyParams;
 
 /**
  * Created by cliff on 5/14/14.
@@ -36,7 +36,7 @@ public class TupleAllocatorGenerator extends ClassBodyEvaluator {
         return (TupleAllocator) allocatorClass.getConstructor().newInstance();
     }
 
-    private Java.PackageMemberClassDeclaration makeClassDefinition(Location loc, Class <?>tupleClass, String className) {
+    private Java.PackageMemberClassDeclaration makeClassDefinition(Location loc, Class<?> tupleClass, String className) {
         Java.PackageMemberClassDeclaration cd = new Java.PackageMemberClassDeclaration(
                 loc,
                 null,
@@ -48,7 +48,6 @@ public class TupleAllocatorGenerator extends ClassBodyEvaluator {
                         classToType(loc, TupleAllocator.class)
                 });
 
-        cd.addConstructor(nullConstructor(loc));
         cd.addDeclaredMethod(new Java.MethodDeclarator(
                 loc,
                 null,

--- a/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleExpressionGenerator.java
+++ b/fasttuple-core/src/main/java/com/nickrobison/tuple/codegen/TupleExpressionGenerator.java
@@ -157,7 +157,6 @@ public class TupleExpressionGenerator extends ClassBodyEvaluator {
                 }
         );
         cu.addPackageMemberTypeDeclaration(cd);
-        cd.addConstructor(nullConstructor(loc));
         cd.addDeclaredMethod(generateFrontendMethod(loc));
         cd.addDeclaredMethod(generateBackendMethod(parser));
         this.evaluatorClass = compileToClass(cu);

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/TuplePoolTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/TuplePoolTest.java
@@ -88,15 +88,14 @@ public class TuplePoolTest {
                     Arrays.fill(ary, 0L);
                     return ary;
                 },
-                ary -> {
+                ary -> destroyed.set(true));
 
-                });
-
-        pool.checkout();
+        final Long value = pool.checkout();
         pool.close();
+        assertThrows(IllegalStateException.class, () -> pool.release(value));
         final IllegalStateException exn = assertThrows(IllegalStateException.class, pool::checkout);
         assertEquals("Pool's closed everyone out!", exn.getLocalizedMessage());
-//        assertTrue(destroyed.get()); // FIXME: Destroyer is never actually called
+        assertTrue(destroyed.get());
     }
 
     @Test

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/HeapTupleCodeGeneratorTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/HeapTupleCodeGeneratorTest.java
@@ -5,6 +5,8 @@ import com.nickrobison.tuple.HeapTupleSchema;
 import com.nickrobison.tuple.TupleSchema;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -26,6 +28,7 @@ public class HeapTupleCodeGeneratorTest {
 
         HeapTupleCodeGenerator codegen = new HeapTupleCodeGenerator(null, schema.getFieldNames(), schema.getFieldTypes());
         Class<?> clazz = codegen.cookToClass();
+        assertNullConstructorGenerated(clazz);
         assertGetterAndSetterGenerated(clazz, "a", long.class);
         assertGetterAndSetterGenerated(clazz, "b", int.class);
         assertGetterAndSetterGenerated(clazz, "c", short.class);
@@ -109,7 +112,7 @@ public class HeapTupleCodeGeneratorTest {
                 heapMemory().
                 build();
         FastTuple tuple = schema.createTuple();
-        assertTrue(tuple instanceof StaticBinding);
+        assertInstanceOf(StaticBinding.class, tuple);
     }
 
     public void assertGetterAndSetterGenerated(Class<?> clazz, String name, Class<?> type) throws Exception {
@@ -152,6 +155,17 @@ public class HeapTupleCodeGeneratorTest {
         }
     }
 
+    public void assertNullConstructorGenerated(Class<?> clazz) {
+        // Check for a no-arg constructor
+        try {
+            final Constructor<?> declaredConstructor = clazz.getDeclaredConstructor();
+            assertEquals(0, declaredConstructor.getParameterTypes().length);
+        } catch (NoSuchMethodException e) {
+            fail("No-arg constructor not found in class: " + clazz.getName());
+        }
+    }
+
+    @SuppressWarnings("unused")
     public interface StaticBinding {
         void a(long a);
         long a();

--- a/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/TupleExpressionGeneratorTest.java
+++ b/fasttuple-core/src/test/java/com/nickrobison/tuple/codegen/TupleExpressionGeneratorTest.java
@@ -217,4 +217,30 @@ public class TupleExpressionGeneratorTest {
 
         assertThrows(CompileException.class, () -> TupleExpressionGenerator.builder().expression("tuple.a + tuple.b == tuple.c").schema(schema).returnDouble());
     }
+
+
+    @SuppressWarnings({"EqualsBetweenInconvertibleTypes", "SimplifiableAssertion", "EqualsWithItself"})
+    @Test
+    void testEqualsHashCode() throws Exception {
+        TupleSchema schema = TupleSchema.builder().
+                addField("a", Double.TYPE).
+                addField("b", Double.TYPE).
+                addField("c", Double.TYPE).
+                heapMemory().
+                build();
+
+        assertFalse(schema.equals("Hello"));
+
+        TupleExpressionGenerator.TupleExpression expr1 = TupleExpressionGenerator.builder().expression("tuple.a(100), tuple.b(200), tuple.c(300)").schema(schema).returnVoid();
+        TupleExpressionGenerator.TupleExpression expr2 = TupleExpressionGenerator.builder().expression("tuple.a(100), tuple.b(200), tuple.c(300)").schema(schema).returnVoid();
+        TupleExpressionGenerator.TupleExpression expr3 = TupleExpressionGenerator.builder().expression("tuple.a(100), tuple.b(200), tuple.c(500)").schema(schema).returnVoid();
+        assertFalse(expr1.equals("Hello"));
+        assertTrue(expr1.equals(expr1));
+        assertFalse(expr1.hashCode() == expr2.hashCode());
+        assertFalse(expr1.equals(expr2));
+        assertFalse(expr1.hashCode() == expr2.hashCode());
+        assertFalse(expr1.equals(expr3));
+        assertFalse(expr1.hashCode() == expr3.hashCode());
+
+    }
 }


### PR DESCRIPTION
In preparation for upgrading Janino this PR makes some small tweaks to our test suite in order to improve the Pitest coverage.

We're still not totally there yet, some of which will be added when we do String support in #88.

I did fix the TuplePool cleanup issue, so we can now close #30.

We also no longer mutate the Direct memory classes, since that just causes the the JVM to die and no coverage to be reported.